### PR TITLE
Add instruction to install compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ First, install grunt and bower
 
     sudo npm install -g grunt-cli bower
 
+Then, install compass
+
+    # Ensure to have a working version of Ruby and RubyGems first
+    sudo gem install compass
+
 Switch to hull-js dir
 
     cd hull-js


### PR DESCRIPTION
When you start with a clean environment, `grunt build` will fail because compass is not present:

```
Running "compass:prod" (compass) task
/Users/xdutreilh/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/rubygems/dependency.rb:296:in `to_specs': Could not find 'compass' (>= 0) among 65 total gem(s) (Gem::LoadError)
    from /Users/xdutreilh/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/rubygems/dependency.rb:307:in `to_spec'
    from /Users/xdutreilh/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/rubygems/core_ext/kernel_gem.rb:47:in `gem'
    from /Users/xdutreilh/.rbenv/versions/2.0.0-p0/bin/compass:22:in `<main>'
```

The pull request updates the README to make this dependency explicit (as well as Ruby and RubyGems). Not so much, but still useful.
