### PR TITLE
Feature/humanized errors

### DIFF
--- a/.grunt/api.json
+++ b/.grunt/api.json
@@ -34,8 +34,8 @@
       ],
     "out": "dist/<%= PKG_VERSION %>/hull.api.js",
     "wrap": {
-      "start": "(function(){var require, requirejs, define, root={}, HULL_ENV='api'; (function () {",
-      "end": ";}).call(root);})();"
+      "startFile": [".grunt/wrappers/start.api.frag"],
+      "endFile": [".grunt/wrappers/end.frag"]
     }
   }
 }

--- a/.grunt/client.json
+++ b/.grunt/client.json
@@ -52,8 +52,8 @@
       ],
     "out": "dist/<%= PKG_VERSION %>/hull.js",
     "wrap": {
-      "start": "(function(){var require, requirejs, define, root={jQuery: window.jQuery}, HULL_ENV = 'client'; (function () {",
-      "end": ";}).call(root);})();"
+      "startFile": [".grunt/wrappers/start.client.frag"],
+      "endFile": [".grunt/wrappers/end.frag"]
     }
   }
 }

--- a/.grunt/wrappers/end.frag
+++ b/.grunt/wrappers/end.frag
@@ -1,0 +1,45 @@
+    ;
+  };
+
+  var location = this.location;
+  if (location.protocol && !location.protocol.match(/^http/)) {
+    var d = document.createElement('div');
+    var docs = document.createElement('a');
+    docs.href="http://hull.io/docs/hull_js";
+    docs.innerHTML = "Documentation";
+    var aStyles = [
+      "float: right",
+      "background-color: lightgrey",
+      "padding: 4px 7px",
+      "font-weight: bold",
+      "color: #C7006F",
+      "border-radius: 5px",
+      "margin: 0 30px"
+    ];
+    docs.setAttribute("style", aStyles.join(";"))
+    var styles = [
+      "position:fixed",
+      "top:0",
+      "left:0",
+      "right:0",
+      "padding: 15px 0",
+      "font-size: 18px",
+      "background-color:#C7006F",
+      "text-align: center",
+      "color: white",
+      "font-family: sans-serif",
+      "line-height: 20px"
+    ];
+    d.setAttribute("style", styles.join(";"))
+    var message = "Hull.js can't be run from a local file.";
+    var text = document.createElement('span');
+    text.innerHTML = message;
+    d.appendChild(docs);
+    d.appendChild(text);
+    document.write(d.outerHTML);
+    
+    throw message;
+  } else {
+    lib.call(root);
+  }
+})();

--- a/.grunt/wrappers/end.frag
+++ b/.grunt/wrappers/end.frag
@@ -1,20 +1,20 @@
     ;
   };
 
-  var location = this.location;
-  if (location.protocol && !location.protocol.match(/^http/)) {
+  var __hull__flash = function (message) {
     var d = document.createElement('div');
     var docs = document.createElement('a');
+    docs.target = '_blank';
     docs.href="http://hull.io/docs/hull_js";
     docs.innerHTML = "Documentation";
     var aStyles = [
       "float: right",
-      "background-color: lightgrey",
-      "padding: 4px 7px",
-      "font-weight: bold",
-      "color: #C7006F",
-      "border-radius: 5px",
-      "margin: 0 30px"
+      "background-color: whitesmoke",
+      "padding: 0px 10px",
+      "color: #C70040",
+      "border-radius: 2px",
+      "margin: 0 30px 0 0",
+      "text-decoration: none"
     ];
     docs.setAttribute("style", aStyles.join(";"))
     var styles = [
@@ -24,20 +24,23 @@
       "right:0",
       "padding: 15px 0",
       "font-size: 18px",
-      "background-color:#C7006F",
+      "background-color:#C70040",
       "text-align: center",
       "color: white",
       "font-family: sans-serif",
       "line-height: 20px"
     ];
     d.setAttribute("style", styles.join(";"))
-    var message = "Hull.js can't be run from a local file.";
     var text = document.createElement('span');
     text.innerHTML = message;
     d.appendChild(docs);
     d.appendChild(text);
     document.write(d.outerHTML);
-    
+  };
+
+  var location = this.location;
+  if (location.protocol && !location.protocol.match(/^http/)) {
+    __hull__flash("Hull.js can't be run from a local file.");
     throw message;
   } else {
     lib.call(root);

--- a/.grunt/wrappers/start.api.frag
+++ b/.grunt/wrappers/start.api.frag
@@ -1,0 +1,7 @@
+(function(){
+  var require,
+      requirejs,
+      define,
+      root= {},
+      HULL_ENV='api';
+  function lib() {

--- a/.grunt/wrappers/start.client.frag
+++ b/.grunt/wrappers/start.client.frag
@@ -1,0 +1,7 @@
+(function(){
+  var require,
+      requirejs,
+      define,
+      root = { jQuery: window.jQuery },
+      HULL_ENV = 'client';
+  function lib() {

--- a/src/api/api.coffee
+++ b/src/api/api.coffee
@@ -59,7 +59,6 @@ define ['lib/utils/flash', 'underscore', '../utils/cookies', '../utils/version',
       rpc = readyObj.rpc
       onRemoteReady readyObj.config
     , (err)->
-      flash(err)
       dfd.reject err
 
     ###

--- a/src/api/api.coffee
+++ b/src/api/api.coffee
@@ -1,4 +1,4 @@
-define ['underscore', '../utils/cookies', '../utils/version', '../api/params', '../api/auth', '../utils/promises', 'lib/api/xdm'], (_, cookie, version, apiParams, authModule, promises, xdm)->
+define ['lib/utils/flash', 'underscore', '../utils/cookies', '../utils/version', '../api/params', '../api/auth', '../utils/promises', 'lib/api/xdm'], (flash, _, cookie, version, apiParams, authModule, promises, xdm)->
   slice = Array.prototype.slice
 
   init : (config={}, emitter)->
@@ -6,8 +6,13 @@ define ['underscore', '../utils/cookies', '../utils/version', '../api/params', '
 
     # Fail right now if we don't have the required setup
     unless config.orgUrl and config.appId
-      dfd.reject(new ReferenceError 'no organizationURL provided. Can\'t proceed') unless config.orgUrl
-      dfd.reject(new ReferenceError 'no applicationID provided. Can\'t proceed') unless config.appId
+      unless config.orgUrl
+        msg = "No 'orgUrl' parameter passed to Hull.init. Can't proceed."
+      unless config.appId
+        msg = "No 'appId' parameter passed to Hull.init. Can't proceed."
+      if msg
+        flash msg
+        dfd.reject(new ReferenceError msg)
       return dfd.promise
 
     message = null
@@ -55,6 +60,7 @@ define ['underscore', '../utils/cookies', '../utils/version', '../api/params', '
       rpc = readyObj.rpc
       onRemoteReady readyObj.config
     , (err)->
+      flash(err)
       dfd.reject err
 
     ###

--- a/src/api/api.coffee
+++ b/src/api/api.coffee
@@ -10,9 +10,8 @@ define ['lib/utils/flash', 'underscore', '../utils/cookies', '../utils/version',
         msg = "No 'orgUrl' parameter passed to Hull.init. Can't proceed."
       unless config.appId
         msg = "No 'appId' parameter passed to Hull.init. Can't proceed."
-      if msg
-        flash msg
-        dfd.reject(new ReferenceError msg)
+      flash msg
+      dfd.reject(new ReferenceError msg)
       return dfd.promise
 
     message = null

--- a/src/api/xdm.coffee
+++ b/src/api/xdm.coffee
@@ -16,7 +16,6 @@ define ['domready', 'lib/utils/promises', 'xdm', 'lib/utils/version'], (domready
     deferred = promises.deferred()
 
     onMessage = (e)->
-      console.log('remoteMessage', e)
       if e.error
         deferred.reject e.error
       else

--- a/src/hull.coffee
+++ b/src/hull.coffee
@@ -68,5 +68,5 @@ define ['underscore', 'lib/utils/promises', 'aura/aura', 'lib/utils/handlebars',
     exports: booted
     context: apiParts.context
   failure: (error)->
-    console.error(error.message)
+    console.error(error.message || error)
     error

--- a/src/remote/services.coffee
+++ b/src/remote/services.coffee
@@ -35,5 +35,6 @@ define ['underscore', 'xdm'], (_, xdm)->
       true
 
     afterAppStart: (app)->
+      return unless rpc
       rpc.ready(app.config)
       app.sandbox.on 'remote.user.update', rpc.userUpdate.bind(rpc)

--- a/src/utils/flash.coffee
+++ b/src/utils/flash.coffee
@@ -1,0 +1,4 @@
+#global __hull__flash:true
+define ()->
+  return __hull__flash if __hull__flash?
+  ()->


### PR DESCRIPTION
Displays a banner for critical errors:

* Unable to start remote
* No appId/orgUrl
* app started from a `file://`
* Unauthorized domain