### PR TITLE
Prevents emitting user update events on false positives

### DIFF
--- a/src/remote/current-user.coffee
+++ b/src/remote/current-user.coffee
@@ -21,8 +21,10 @@ define ()->
       if !userManager.is(userId) # It changed
         delete app.core.handler.headers['Hull-Access-Token']
         p1 = userManager.updateDescription().then (h)->
+          previousUserId = userManager.currentUser?.id
           userManager.currentUser = h.response
-          app.sandbox.emit 'remote.user.update', h.response
+          hasChanged = previousUserId != h.response?.id
+          app.sandbox.emit 'remote.user.update', h.response if hasChanged
         , (err)->
           userManager.currentUser = {}
           app.sandbox.emit 'remote.user.update', {}
@@ -37,7 +39,7 @@ define ()->
       else if userManager.isUserUpdate(h.response)
         userManager.currentUser = h.response
         app.sandbox.emit 'remote.user.update', userManager.currentUser
-        
+
 
 
 


### PR DESCRIPTION
Some requests don't sent Hull-User-Id.
In order to not reload the page in such a case, we first double check by using the newly fetched credentials and comparing IDs.

Reproducible in the admin, with : `Hull.api('users', {}, 'put')`