### PR TITLE
Fixes mapping of services in config

### DIFF
--- a/spec/remote/config-normalizer_spec.js
+++ b/spec/remote/config-normalizer_spec.js
@@ -33,7 +33,7 @@ define(['lib/remote/config-normalizer'], function (CfgNorm) {
       };
       var types = {
         auth: ['fb_app', 'abc'],
-        other: ['mp']
+        other: ['mp', 'np_stuff']
       };
       this.normalizer.sortServicesByType(settings, types).should.eql({
         auth: {
@@ -41,7 +41,8 @@ define(['lib/remote/config-normalizer'], function (CfgNorm) {
           abc: {}
         },
         other: {
-          mp: {}
+          mp: {},
+          np: {}
         }
       });
     });

--- a/src/remote/config-normalizer.coffee
+++ b/src/remote/config-normalizer.coffee
@@ -1,7 +1,9 @@
 define ['underscore'], (_)->
 
   flattenSettings = (settings, name)->
-    [name.replace(/_app$/, ''), settings[name] || {}]
+    nameArray = name.split('_')
+    nameArray.pop() if nameArray.length > 1
+    [nameArray.join('_'), settings[name] || {}]
 
   class ConfigNormalizer
     constructor: (cfg)->


### PR DESCRIPTION
Can be easily reproduces when using a `hull_store`. The following describes the behaviour before this PR
1. Start an app anonymously
2. Hull.config("services.storage") has a key `hull_store`
3. Login
4. Hull.config("services.storage") has a key `hull`

With this PR, only the key `hull` will ever be available.
