### PR TITLE
Support `data-` prefix for attributes in Snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * Remove dependency to polyfill service
 * Upgrade dependencies
 * Silence warnings on bluebird promises
-
+* Support `data-*` configuration attributes on `src` tag
+* Update Documentation
+* Add `npm run build` task
 
 # 0.9.0
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -10,10 +10,9 @@ It is the library you install when you paste a Platform snippet in your page's `
 ```html
 <script 
   id="hull-js-sdk"
-  platform-id="YOUR_PLATFORM_ID"
-  org-url="https://ORG_NAMESPACE.hullapp.io"
+  data-platform-id="YOUR_PLATFORM_ID"
+  data-org-url="https://ORG_NAMESPACE.hullapp.io"
   src="https://js.hull.io/0.10.0/hull.js.gz"></script>
-
 ```
 
 
@@ -32,7 +31,7 @@ It is the library you install when you paste a Platform snippet in your page's `
 ```
 
 - If you use the platform Snippet as is, the library is initialized automatically with the right organization and platform.</li>
-- If you do not need to use Ships or you need more control, you can disable auto-initialization and boot Hull manually. We recommend sticking with the automatic initialization if you don't have a specific scenario requiring manual init. </li>
+- If you do not need to use Connectors or you need more control, you can disable auto-initialization and boot Hull manually. We recommend sticking with the automatic initialization if you don't have a specific scenario requiring manual init. </li>
 
 ### Initialization parameters
 
@@ -50,7 +49,7 @@ orgUrl | String | The URL of your organization _e.g._ `YOUR_ORG.hullapp.io`
 Parameter | Type | Description
 ----------|------|------------
 autoStart | String | Default: `true`, Auto Start Hull on load (call `Hull.init()`).
-embed | Boolean | Default:`true`. Skip embedding Ships in the page.
+embed | Boolean | Default:`true`. Skip embedding Connectors in the page.
 debug | Boolean | Default:`false`. Log messages. VERY useful during development to catch errors in promise chains.
 verbose | Boolean | Default:`false`. Log even more things such as network traffic. Needs `debug: true`
 accessToken | String | A signed JWT, telling Hull to automatically log-in a user fetched from your backend. See ["Bring your own users"](#bring-your-own-users)
@@ -71,7 +70,7 @@ Hull.on('hull.ready', function (hull, me, platform, org) {
 });
 
 Hull.on('hull.ships.ready', function () {
-  console.log('Ships are available in page');
+  console.log('Connectors are available in page');
 });
 ```
 
@@ -79,7 +78,7 @@ Hull.on('hull.ships.ready', function () {
 
 Use `Hull.ready()` to call a function as soon as `hull.js` is
 initialized. If you call the function after the initialization is
-done, the function is called immediately. Inside [Ships](/docs/apps/ships), You will probably use `Hull.onEmbed()` instead.
+done, the function is called immediately. Inside [Connectors](/docs/apps/ships), You will probably use `Hull.onEmbed()` instead.
 
 ### `Hull.on()`
 
@@ -96,7 +95,13 @@ Track something. See [Tracking](#tracking)
 ## Asynchronous snippet
 
 ```html
-<%=hulljs_snippet(true)%>
+<script 
+  async defer
+  id="hull-js-sdk"
+  data-platform-id="YOUR_PLATFORM_ID"
+  data-org-url="https://ORG_NAMESPACE.hullapp.io"
+  src="https://js.hull.io/0.10.0/hull.js.gz"></script>
+
 <script>
   window.hullAsyncInit = function(hull){
     console.log('Hull Async Init', hull),
@@ -114,7 +119,7 @@ Track something. See [Tracking](#tracking)
   }
 </script>
 ```
-If you're embedding the snippet with the `async` parameter, Hull will load asynchronously and the `Hull` object won't be available immediately.
+If you're embedding the snippet with the `async defer` parameter, Hull will load asynchronously and the `Hull` object won't be available immediately.
 You can define then a function called `hullAsyncInit` attached to `window`. It will get called when the Hull object is available.
 
 
@@ -296,8 +301,8 @@ Hull.init({
 ```html
 <script
   id="hull-js-sdk"
-  platform-id="YOUR_PLATFORM_ID"
-  org-url="https://ORG_NAMESPACE.hullapp.io"
+  data-platform-id="YOUR_PLATFORM_ID"
+  data-org-url="https://ORG_NAMESPACE.hullapp.io"
   access-token="SIGNED_JSON_WEB_TOKEN_FROM_BACKEND"
   src="https://js.hull.io/0.10.0/hull.js.gz"></script>
 ```
@@ -631,37 +636,11 @@ hull.utils.assign()
 hull.utils.uuid()
 ```
 
-### Encoding a String to an Entity Unique ID
+# Messages
 
-`Hull.entity.encode()` encodes a String to base64-valid entity Unique ID, for use in a `Hull.api()` call.
+The Hull library embeds a message bus to which you can subscribe to be notified of lifecycle events, and emit your own events as needed.
 
-```js
-Hull.entity.encode("http://www.imdb.com/title/tt0829482/");
-//=> "~aHR0cDovL3d3dy5pbWRiLmNvbS90aXRsZS90dDA4Mjk0ODI="
-```
-
-### Decoding an Entity UID
-
-`Hull.entity.decode()` decodes an Entity Unique ID back into a String.
-
-```js
-Hull.entity.decode("~aHR0cDovL3d3dy5pbWRiLmNvbS90aXRsZS90dDA4Mjk0ODI=");
-//=> "http://www.imdb.com/title/tt0829482/"
-```
-
-### Flagging content
-
-#### Hull.flag()
-The `Hull.flag` method is syntactic sugar for the `/flag` API route. It lets users report content as inappropriate like this:
-
-```js
-var commentId = '52e568a57d9bcc595a001b42';
-Hull.flag(commentId);
-```
-
-# Events
-
-## Subscribe to an event
+## Subscribe to a message channel
 
 > This method is available immediately at launch
 
@@ -688,19 +667,19 @@ You subscribe to them with the `Hull.on()` method:
 - The current Event name is available in `this.event`
 - It is useful to adapt react on Hull's state
 
-### Event list
+### Message list
 Event Name | Description | Arguments
 -----------|-------------|----------
-hull.ready        | `hull.js` has finished loading. | `Hull`, `me`, `app`, `org`
-hull.ships.ready  | Ships are loaded.               | nothing
-hull.user.create  | User signed up.                 | `me`
-hull.user.login   | User logged in.             | `me`
-hull.user.logout  | User logged out.            | `me`
-hull.user.fail    | User failed to log in.      | `error`
-hull.user.update  | User updated any property   | `me`
-hull.PROVIDER.share | `Hull.share()` called     | nothing
-hull.track       | `Hull.track()` called. Use to funnel events to your analytics tool | `properties`
-hull.traits      | `Hull.traits()` called. Use to send properties to your CRM or customer-centric database | `event`
+`hull.ready`        | `hull.js` has finished loading. | `Hull`, `me`, `app`, `org`
+`hull.ships.ready`  | Connectors are loaded.               | nothing
+`hull.user.create`  | User signed up.                 | `me`
+`hull.user.login`   | User logged in.             | `me`
+`hull.user.logout`  | User logged out.            | `me`
+`hull.user.fail`    | User failed to log in.      | `error`
+`hull.user.update`  | User updated any property   | `me`
+`hull.PROVIDER.share` | `Hull.share()` called     | nothing
+`hull.track`       | `Hull.track()` called. | `properties`
+`hull.traits`      | `Hull.traits()` called.  | `event`
 
 ### Parameters
 Parameter | Type | Description
@@ -708,7 +687,7 @@ Parameter | Type | Description
 evtName | String  | The name of the event to attach to.
 cb      | Function | The function to be executed when the event is triggered.
 
-## Unsubscribe from an event
+## Unsubscribe from a message channel
 > This method is available once the app has started. 
 
 ### `Hull.off(evtName, cb)`
@@ -726,7 +705,7 @@ Unregisters the function from the event. As usual in such cases, it the referenc
 If you want to unregister a listener, take great care to ensure that when you do, you pass the __same memory reference__ than when you registered it.
 There is no tool to help you do this, just proper engineering.
 
-## Emit an event.
+## Emit a message
 
 > This method is available once the app has started.
 
@@ -889,21 +868,19 @@ Hull.track('event_name', {
 Track arbitrary additional data.
 
 - If a user is logged in, events will be associated to him.
-- When using Ships, the scoped `hull` object you receive in the `Hull.onEmbed` callback adds information about the current ship. This is the object you should use, instead of the global `Hull` object.
+- When using Connectors, the scoped `hull` object you receive in the `Hull.onEmbed` callback adds information about the current connector. This is the object you should use, instead of the global `Hull` object.
 
 
 
-#### Several events are already tracked automatically.
+#### Auto-Tracked events
 
-* All `PUT`, `POST`, `DELETE` API calls track data automatically. Checkout the [API Reference](/docs/references/api) for details on each tracking call.
-* Login, Logout and Signup methods do tracking calls for you. No need to add them.
+* Page views, Login, Logout and Signup methods do tracking calls for you. No need to add them. Page views will show up as `hull.app.init` in your tools, and as `Viewed PAGE_NAME` in your Hull dashboard
 
 <aside>
   This method is available immediately at launch
 </aside>
 
 # Traits
-
 
 ```js
 Hull.traits({'my new trait': 'has this value'});
@@ -933,17 +910,15 @@ Hull.traits({
 Hull.traits({ 'number_of_coconuts': {operation: 'inc', value: "123"} }) //Increases number of coconuts by 123
 ```
 
-### `Hull.traits({trait_name: value})`
+### `Hull.traits({ trait_name: value })`
 Sets the `value` to the trait of name `trait_name`.
 
 A trait is a property you can define on a User, for analytics and CRM purposes.
 What is stored there is visible only for administrators.
 
-
-
 - We support the following types: `String`, `Number`, `Date`, `Array`
 - We infer the types of a trait so you don't have to specify it. Number and String types are inferred on the type of the value.
-- To store a Date, define a trait that ends with `_at` such as `played_at`.
+- To store a Date, define a trait that ends with `_at` or `_date` such as `played_at` or `activation_date`
 - Once the type of a trait is set, it can not be changed, but you can use as many traits as you like.
 
 Traits let you segment your customers in the [Dashboard](http://dashboard.hullapp.io) with custom criteria.
@@ -952,15 +927,17 @@ Traits let you segment your customers in the [Dashboard](http://dashboard.hullap
   This method is available immediately at launch
 </aside>
 
-# Ships
+# Connectors
 
-When used inside [Ships](/docs/apps/ships), Hull.js exposes methods to help you manage ships.
+Connectors can embed Client-side code, by having Hull.js inject their own Javascript in the page. When used inside [Connectors](/docs/apps/ships), Hull.js exposes methods to help you manage connectors.
 
-## Booting a ship
+## Booting a connector
+
+Connectors can deploy JS code to your page, and expose settings in your dashboard you can use to configure them. Checkout [The docs on Client-side connectors](http://www.hull.io/docs/apps/ships#client-side) to learn more about what is available.
 
 ```js
 Hull.onEmbed(function(rootNode, deployment, hull) {
-  console.log('Hello, i am a Ship and i just started');
+  console.log('Hello, i am a Connector and i just started');
   console.log('Here is my root element : ', rootNode);
   console.log('and here is my environment: ', deployment);
 
@@ -971,33 +948,30 @@ Hull.onEmbed(function(rootNode, deployment, hull) {
 });
 ```
 
-### `Hull.onEmbed(callback)`
-Checkout [Booting your application](/docs/apps/ships#booting-your-application) in the Ships documentation for more details 
-
-## Finding the closest url reference from a ship's root
-### `hull.findUrl()`
-
-```js
-hull.findUrl() //http://some-url.com;
+```javascript
+const deployment = {
+  ship: {} //the connector's settings,
+  platform: {} //the platform's settings,
+  
+}
 ```
 
-Navigates the DOM upwards from the Ship root element to find a URL either from a Link or a "data-hull-link" attribute.
-Useful when trying to share something;
+<aside>
+  The `deployment` object will contain the data you need, including the connector's public settings:
+</aside>
 
-#### Searches in order:
 
-- The DOM for any `href` or `data-hull-link` attribute
-- OG Tags
-- Window's current URL
+### `Hull.onEmbed(callback)`
+Checkout [Booting your application](/docs/apps/ships#booting-your-application) in the Connectors documentation for more details 
 
-## Disabling Ships Automatic embedding
+## Disabling Connectors Automatic embedding
 
 ```html
 <script
   id="hull-js-sdk"
-  embed="false"
-  platform-id="54feb3b0574f8c7692000cfa"
-  org-url="https://hull-demos.hullapp.io"
+  data-embed="false"
+  data-platform-id="54feb3b0574f8c7692000cfa"
+  data-org-url="https://hull-demos.hullapp.io"
   src="https://js.hull.io/0.10.0/hull.js.gz"></script>
 ```
 
@@ -1014,16 +988,16 @@ Useful when trying to share something;
 </script>
 ```
 
-If for some reason you need to prevent auto-embedding of Ships, you can do so with the `embed=false` flag.
-It will be then up to you to start the ships, [Here is where the boot usually starts](https://github.com/hull/hull-js/blob/master/src/hull.coffee#L58), see how to start it yourself.
+If for some reason you need to prevent auto-embedding of Connectors, you can do so with the `embed=false` parameter.
+It will be then up to you to start the connectors, [Here is where the boot usually starts](https://github.com/hull/hull-js/blob/master/src/hull.coffee#L58), see how to start it yourself.
 
-### `Hull.embed`
+### `Hull.embed()` method
 
 ```js
 Hull.ready(function(hull, me, platform, org){
-  Hull.embed(platform.deployments, {reset:false}, callback, errback);  
+  Hull.embed(platform.deployments, { reset:false }, callback, errback);  
 });
 ```
 
-<aside class="warning">This is an advanced method, if you want to start Ships manually. you're on your own ;p</aside>
+<aside class="warning">This is an advanced method, if you want to start connectors manually. you're on your own ;p</aside>
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,5 @@
 # Hull.js [ ![Codeship Status for hull/hull-js](https://circleci.com/gh/hull/hull-js/tree/develop.png?circle-token=26a17dad6ac378f6028a460a5857d5ca15a8aa13) ](https://circleci.com/gh/hull/hull-js)
 
-# Ship Deployment Compatibility Status
-[Table](https://docs.google.com/spreadsheets/d/13lwZP8XmhIBA84bpmKd-96nC9nE9tQaM0c0WgyQNHXI/edit#gid=0.8)
-
-| Device      | OS            | Browser           | Version  | HTMLImports | JS mode | Raw Mode | Scoped Mode | Sandboxed Mode | Notes                                                                            |
-|-------------|---------------|-------------------|----------|-------------|---------|----------|-------------|----------------|----------------------------------------------------------------------------------|
-| Nexus 4     | Android       | Android           | 4.0.0    | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Galaxy S3   | Android       | Android           | 4.1      | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Nexus S     | Android       | Android           | 4.2.2    | OK          |         | OK       | OK          | NO             |                                                                                  |
-| Galaxy S5   | Android       | Android           | 4.4      | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Galaxy S4   | Android       | Android           | 4.4      | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Nexus 5     | Android       | Android           | 4.4      | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Nokia Lumia | Windows Phone | IE Mobile         | 11       | NO          |         | NO       | NO          | NO             |                                                                                  |
-| Desktop     | Mac           | Chrome            | 43       | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Desktop     | Mac           | Firefox           | 36       | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Desktop     | Windows 8     | Internet Explorer | 10       | OK          |         | OK       | OK          | OK             | Scoped : CSS Order Wrong.2= 2 inline 3= 4 ship.html 4= 4 ship.html 5= 5 test.css |
-| Desktop     | Windows 8     | Internet Explorer | 10 Metro | OK          |         | OK       | OK          | OK             | Scoped : CSS Order Wrong.2= 2 inline 3= 4 ship.html 4= 4 ship.html 5= 5 test.css |
-| Desktop     | Windows       | Internet Explorer | 11       | OK          |         | OK       | OK          | OK             |                                                                                  |
-| Desktop     | Windows       | Internet Explorer | 8        | NO          |         | NO       | NO          | NO             |                                                                                  |
-| Desktop     | Windows       | Internet Explorer | 9        | OK          |         | OK       | OK          | OK             | Needs Same-Protocol. (XHR-XDR)2 = 2 inline 3 = 3 main.scss 4 = 4 ship.html 5     |
-| Desktop     | Mac           | Safari            | 8        | OK          |         | OK       | OK          | OK             |                                                                                  |
-
-
-# Sandboxing: 
-We have 3 embed modes, from less to more isolation :
-- JS, (manifest.index == `*.js`) : Dumps the JS in the page at the Insertion point.
-- Scoped (settings.sandbox = `Falsy`) (Scopes Styles automatically)
-- Sandboxed (settings.sandbox = `Truthy`)(Renders everything into a completely isolated container)
-
 # Building the library
 Checkout
 
@@ -41,7 +13,7 @@ Then switch to hull-js dir
 
     cd hull-js
     npm install
-    gulp build
+    npm run build
 
 The last command will start a static HTTP server (port `3001`) that serves the files located in the root folder.
 

--- a/app/index.html
+++ b/app/index.html
@@ -9,6 +9,7 @@
     <title>Hull JS Library</title>
     <script
     debug="true"
+    id="hull-js-sdk"
     data-platform-id="558979b4f59837f6160003c9"
     data-org-url="http://super.hullapp.io"
     data-js-url='http://localhost:3001/hull.js'

--- a/app/index.html
+++ b/app/index.html
@@ -9,9 +9,9 @@
     <title>Hull JS Library</title>
     <script
     debug="true"
-    platform-id="558979b4f59837f6160003c9"
-    org-url="http://super.hullapp.io"
-    jsUrl='http://localhost:3001/hull.js'
+    data-platform-id="558979b4f59837f6160003c9"
+    data-org-url="http://super.hullapp.io"
+    data-js-url='http://localhost:3001/hull.js'
     src="http://localhost:3001/hull.js"></script>
     <script>
       Hull.track('Test Event', {test: 'data'});

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "scripts": {
     "test": "jest",
+    "build": "gulp build",
     "start": "gulp"
   },
   "engines": {

--- a/src/client/script-tag-config.coffee
+++ b/src/client/script-tag-config.coffee
@@ -68,7 +68,7 @@ initParams = {
 }
 
 getAttribute = (el, k)->
-  el.getAttribute(dasherize(k)) || el.getAttribute(k)
+  el.getAttribute("data-" + dasherize(k)) || el.getAttribute("data-" + k) || el.getAttribute(dasherize(k)) || el.getAttribute(k)
 
 getParamValue = (el, param, key)->
   keys = [key].concat(param.altKeys || [])

--- a/src/client/script-tag-config.coffee
+++ b/src/client/script-tag-config.coffee
@@ -84,7 +84,7 @@ getParamValue = (el, param, key)->
   if value? then value else param.default
 
 module.exports = ->
-  hull_js_sdk = document.getElementById('hull-js-sdk') || document.querySelector('[org-url][platform-id]')
+  hull_js_sdk = document.getElementById('hull-js-sdk') || document.querySelector('[org-url][platform-id][data-org-url][data-platform-id]')
 
   return unless hull_js_sdk
 


### PR DESCRIPTION
Google Tag Manager requires valid attributes, our `org-url` and `platform-id` attributes trigger validation errors.

This adds support for `data-` prefixed versions of config attributes.

We make them first because that's the most standard and cleanest way to support those attributes, and it should be promoted as the default.Connectors